### PR TITLE
Handle missing DATABASE_URL with in-memory user store

### DIFF
--- a/Interstellar-5.2.3/index.js
+++ b/Interstellar-5.2.3/index.js
@@ -10,20 +10,20 @@ import fetch from "node-fetch"
 import config from "./config.js"
 import { setupMasqr } from "./Masqr.js"
 import crypto from "node:crypto"
-import pkg from "pg"
-const { Pool } = pkg
+// Fallback to an in-memory user store when DATABASE_URL isn't provided.
+let pool
+const memoryUsers = new Map()
 
-const pool = new Pool({
-  connectionString:
-    process.env.DATABASE_URL ||
-    "postgresql://postgres:mTjSMxKVFSkkUcMneXgFxjVnkoSKoFTF@postgres.railway.internal:5432/railway",
-})
-
-pool
-  .query(
-    "CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)"
-  )
-  .catch((err) => console.error("Failed to ensure users table", err))
+if (process.env.DATABASE_URL) {
+  const pkg = await import("pg")
+  const { Pool } = pkg
+  pool = new Pool({ connectionString: process.env.DATABASE_URL })
+  pool
+    .query("CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)")
+    .catch((err) => console.error("Failed to ensure users table", err))
+} else {
+  console.warn("DATABASE_URL not set; using in-memory user store")
+}
 
 const __dirname = process.cwd()
 const server = http.createServer()
@@ -106,6 +106,13 @@ app.post("/api/signup", async (req, res) => {
     return res.status(400).json({ error: "Missing fields" })
   }
   const hash = crypto.createHash("sha256").update(password).digest("hex")
+  if (!pool) {
+    if (memoryUsers.has(username)) {
+      return res.status(409).json({ error: "User already exists" })
+    }
+    memoryUsers.set(username, hash)
+    return res.json({ success: true })
+  }
   try {
     await pool.query("INSERT INTO users (username, password) VALUES ($1,$2)", [username, hash])
     res.json({ success: true })
@@ -124,6 +131,13 @@ app.post("/api/login", async (req, res) => {
     return res.status(400).json({ error: "Missing fields" })
   }
   const hash = crypto.createHash("sha256").update(password).digest("hex")
+  if (!pool) {
+    const stored = memoryUsers.get(username)
+    if (stored && stored === hash) {
+      return res.json({ success: true })
+    }
+    return res.status(401).json({ error: "Invalid credentials" })
+  }
   try {
     const { rows } = await pool.query("SELECT password FROM users WHERE username=$1", [username])
     if (rows.length && rows[0].password === hash) {
@@ -145,8 +159,7 @@ const routes = [
   { path: "/li", file: "login.html" },
   { path: "/", file: "index.html" },
   { path: "/tos", file: "tos.html" },
-];
-
+]
 
 routes.forEach((route) => {
   app.get(route.path, (req, res) => {


### PR DESCRIPTION
## Summary
- Avoid database connection errors when `DATABASE_URL` is not set by falling back to an in-memory user store.
- Update signup and login routes to use the in-memory store when no database is configured.

## Testing
- `npm start`
- `npm install` *(fails: 403 Forbidden to fetch pg)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c4708d3883228663ce6ab0991ce8